### PR TITLE
Support for Culture and formatting on Parse and TryParse

### DIFF
--- a/RationalTests/ApproximateTests.cs
+++ b/RationalTests/ApproximateTests.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Numerics;
-using System.Text;
+using System.Globalization;
 using NUnit.Framework;
 using Rationals;
 
@@ -77,8 +73,8 @@ namespace RationalTests
             int expectedDenominator)
         {
             // arrange
-            var input = decimal.Parse(inputStr);
-            var tolerance = decimal.Parse(toleranceStr);
+            var input = decimal.Parse(inputStr, CultureInfo.InvariantCulture);
+            var tolerance = decimal.Parse(toleranceStr, CultureInfo.InvariantCulture);
 
             // action
             var rational = Rational.Approximate(input, tolerance);

--- a/RationalTests/ExplicitFloatingPointConversionsTests.cs
+++ b/RationalTests/ExplicitFloatingPointConversionsTests.cs
@@ -9,11 +9,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+using System.Globalization;
 using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
@@ -102,7 +99,7 @@ namespace RationalTests
         public void FromDecimal(string inputStr, long expectedNumerator, long expectedDenominator)
         {
             // arrange
-            var input = decimal.Parse(inputStr);
+            var input = decimal.Parse(inputStr, CultureInfo.InvariantCulture);
 
             // action
             var rational = (Rational) input;

--- a/RationalTests/ParsingTests.cs
+++ b/RationalTests/ParsingTests.cs
@@ -8,12 +8,7 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Numerics;
-using System.Text;
+using System.Globalization;
 using NUnit.Framework;
 using Rationals;
 
@@ -44,7 +39,7 @@ namespace RationalTests
             Rational result;
 
             // action
-            var success = Rational.TryParse(input, out result);
+            var success = Rational.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
 
             // assert
             Assert.AreEqual(expectedSuccess, success);
@@ -65,7 +60,7 @@ namespace RationalTests
             Rational result;
 
             // action
-            var success = Rational.TryParseDecimal(input, out result, (decimal)tolerance);
+            var success = Rational.TryParseDecimal(input, NumberStyles.Float, CultureInfo.InvariantCulture, out result, (decimal)tolerance);
 
             // assert
             Assert.AreEqual(expectedSuccess, success);

--- a/Rationals/Parsing.cs
+++ b/Rationals/Parsing.cs
@@ -9,11 +9,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+using System.Globalization;
 using System.Numerics;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Rationals
@@ -27,10 +24,31 @@ namespace Rationals
             new Regex(@"^\s*(?<Whole>-?\d+)\s*[+]\s*(?<Numerator>-?\d+)/(?<Denominator>-?\d+)\s*$",
                 RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-        public static Rational Parse(string s)
+        public static Rational Parse(string value)
+        {
+            return Parse(value, NumberStyles.Float, NumberFormatInfo.CurrentInfo);
+        }
+
+        public static Rational Parse(string value, NumberStyles style)
+        {
+            return Parse(value, style, NumberFormatInfo.CurrentInfo);
+        }
+
+        public static Rational Parse(string value, IFormatProvider provider)
+        {
+            return Parse(value, NumberStyles.Float, NumberFormatInfo.GetInstance(provider));
+        }
+
+        public static Rational Parse(string value, NumberStyles style, IFormatProvider provider)
+        {
+            return Parse(value, style, NumberFormatInfo.GetInstance(provider));
+        }
+
+        private static Rational Parse(string value, NumberStyles style, NumberFormatInfo info)
         {
             Rational result;
-            if (!TryParse(s, out result))
+
+            if (!TryParse(value, style, info, out result))
             {
                 throw new FormatException("Cannot parse string as Rational, the input is in incorrect format.");
             }
@@ -38,27 +56,37 @@ namespace Rationals
             return result;
         }
 
-        public static bool TryParse(string s, out Rational result)
+        public static bool TryParse(string value, out Rational result)
+        {
+            return TryParse(value, NumberStyles.Float, NumberFormatInfo.CurrentInfo, out result);
+        }
+
+        public static bool TryParse(string value, NumberStyles style, IFormatProvider provider, out Rational result)
+        {
+            return TryParse(value, style, NumberFormatInfo.GetInstance(provider), out result);
+        }
+
+        private static bool TryParse(string value, NumberStyles style, NumberFormatInfo info, out Rational result)
         {
             result = default(BigInteger);
 
             try
             {
-                var match = FractionFormat.Match(s);
+                var match = FractionFormat.Match(value);
                 if (match.Success)
                 {
-                    var numerator = BigInteger.Parse(match.Groups["Numerator"].Value);
-                    var denominator = BigInteger.Parse(match.Groups["Denominator"].Value);
+                    var numerator = BigInteger.Parse(match.Groups["Numerator"].Value, style, info);
+                    var denominator = BigInteger.Parse(match.Groups["Denominator"].Value, style, info);
                     result = new Rational(numerator, denominator);
                     return true;
                 }
 
-                match = WholeFractionalFormat.Match(s);
+                match = WholeFractionalFormat.Match(value);
                 if (match.Success)
                 {
-                    var whole = BigInteger.Parse(match.Groups["Whole"].Value);
-                    var numerator = BigInteger.Parse(match.Groups["Numerator"].Value);
-                    var denominator = BigInteger.Parse(match.Groups["Denominator"].Value);
+                    var whole = BigInteger.Parse(match.Groups["Whole"].Value, style, info);
+                    var numerator = BigInteger.Parse(match.Groups["Numerator"].Value, style, info);
+                    var denominator = BigInteger.Parse(match.Groups["Denominator"].Value, style, info);
                     result = new Rational(whole) + new Rational(numerator, denominator);
                     return true;
                 }
@@ -69,7 +97,7 @@ namespace Rationals
             }
 
             BigInteger justWhole;
-            if (BigInteger.TryParse(s, out justWhole))
+            if (BigInteger.TryParse(value, style, info, out justWhole))
             {
                 result = new Rational(justWhole);
                 return true;
@@ -78,10 +106,30 @@ namespace Rationals
             return false;
         }
 
-        public static Rational ParseDecimal(string s, decimal tolerance = 0)
+        public static Rational ParseDecimal(string value, decimal tolerance = 0)
+        {
+            return ParseDecimal(value, NumberStyles.Float, NumberFormatInfo.CurrentInfo, tolerance);
+        }
+
+        public static Rational ParseDecimal(string value, NumberStyles style, decimal tolerance = 0)
+        {
+            return ParseDecimal(value, style, NumberFormatInfo.CurrentInfo, tolerance);
+        }
+
+        public static Rational ParseDecimal(string value, IFormatProvider provider, decimal tolerance = 0)
+        {
+            return ParseDecimal(value, NumberStyles.Float, NumberFormatInfo.GetInstance(provider), tolerance);
+        }
+
+        public static Rational ParseDecimal(string value, NumberStyles style, IFormatProvider provider, decimal tolerance = 0)
+        {
+            return ParseDecimal(value, style, NumberFormatInfo.GetInstance(provider), tolerance);
+        }
+
+        private static Rational ParseDecimal(string value, NumberStyles style, NumberFormatInfo info, decimal tolerance = 0)
         {
             Rational result;
-            if (!TryParseDecimal(s, out result))
+            if (!TryParseDecimal(value, style, info, out result))
             {
                 throw new FormatException("Cannot parse string as Rational, the input is in incorrect format.");
             }
@@ -89,11 +137,21 @@ namespace Rationals
             return result;
         }
 
-        public static bool TryParseDecimal(string s, out Rational result, decimal tolerance = 0)
+        public static bool TryParseDecimal(string value, out Rational result, decimal tolerance = 0)
+        {
+            return TryParseDecimal(value, NumberStyles.Float, NumberFormatInfo.CurrentInfo, out result, tolerance);
+        }
+
+        public static bool TryParseDecimal(string value, NumberStyles style, IFormatProvider provider, out Rational result, decimal tolerance = 0)
+        {
+            return TryParseDecimal(value, style, NumberFormatInfo.GetInstance(provider), out result, tolerance);
+        }
+
+        private static bool TryParseDecimal(string value, NumberStyles style, NumberFormatInfo info, out Rational result, decimal tolerance = 0)
         {
             decimal d;
 
-            if (!decimal.TryParse(s, out d))
+            if (!decimal.TryParse(value, style, info, out d))
             {
                 result = default(Rational);
                 return false;


### PR DESCRIPTION
My machine uses a German locale in which the comma is for floating point separator and dots for thousand separators. Some of the decimal parsing tests were failing on my machine because there was no way to use an InvariantCulture or to specify a culture to use.

Here is the fix for that.