### PR TITLE
Organizing the tests on Categories

### DIFF
--- a/RationalTests/ApproximateTests.cs
+++ b/RationalTests/ApproximateTests.cs
@@ -9,17 +9,17 @@ using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Approximation")]
     public class ApproximateTests
     {
-        [TestCase(0.333f, 0.0001f, 333, 1000)]
-        [TestCase(-0.333f, 0.0001f, -333, 1000)]
-        [TestCase(0.333f, 0.001f, 1, 3)]
-        [TestCase(-0.333f, 0.001f, -1, 3)]
-        [TestCase(2.5f, 0f, 5, 2)]
-        [TestCase(-2.5f, 0f, -5, 2)]
-        [TestCase(-1f, 0f, -1, 1)]
-        [TestCase(1f, 0f, 1, 1)]
+        [TestCase(0.333f, 0.0001f, 333, 1000, Category = "ApproximateFloat")]
+        [TestCase(-0.333f, 0.0001f, -333, 1000, Category = "ApproximateFloat")]
+        [TestCase(0.333f, 0.001f, 1, 3, Category = "ApproximateFloat")]
+        [TestCase(-0.333f, 0.001f, -1, 3, Category = "ApproximateFloat")]
+        [TestCase(2.5f, 0f, 5, 2, Category = "ApproximateFloat")]
+        [TestCase(-2.5f, 0f, -5, 2, Category = "ApproximateFloat")]
+        [TestCase(-1f, 0f, -1, 1, Category = "ApproximateFloat")]
+        [TestCase(1f, 0f, 1, 1, Category = "ApproximateFloat")]
         public void ApproximateFloat(float input, float tolerance, int expectedNumerator, int expectedDenominator)
         {
             // action
@@ -29,14 +29,14 @@ namespace RationalTests
             Assert.AreEqual((Rational) expectedNumerator / expectedDenominator, rational);
         }
 
-        [TestCase(0.333d, 0.0001d, 333, 1000)]
-        [TestCase(-0.333d, 0.0001d, -333, 1000)]
-        [TestCase(0.333d, 0.001d, 1, 3)]
-        [TestCase(-0.333d, 0.001d, -1, 3)]
-        [TestCase(2.5d, 0d, 5, 2)]
-        [TestCase(-2.5d, 0d, -5, 2)]
-        [TestCase(-1d, 0d, -1, 1)]
-        [TestCase(1d, 0d, 1, 1)]
+        [TestCase(0.333d, 0.0001d, 333, 1000, Category = "ApproximateDouble")]
+        [TestCase(-0.333d, 0.0001d, -333, 1000, Category = "ApproximateDouble")]
+        [TestCase(0.333d, 0.001d, 1, 3, Category = "ApproximateDouble")]
+        [TestCase(-0.333d, 0.001d, -1, 3, Category = "ApproximateDouble")]
+        [TestCase(2.5d, 0d, 5, 2, Category = "ApproximateDouble")]
+        [TestCase(-2.5d, 0d, -5, 2, Category = "ApproximateDouble")]
+        [TestCase(-1d, 0d, -1, 1, Category = "ApproximateDouble")]
+        [TestCase(1d, 0d, 1, 1, Category = "ApproximateDouble")]
         public void ApproximateDouble(double input, double tolerance, int expectedNumerator, int expectedDenominator)
         {
             // action
@@ -46,16 +46,16 @@ namespace RationalTests
             Assert.AreEqual((Rational) expectedNumerator / expectedDenominator, rational);
         }
 
-        [TestCase(3, 1, 1.42E-1)]
-        [TestCase(22, 7, 1.27E-3)]
-        [TestCase(333, 106, 8.33E-5)]
-        [TestCase(355, 113, 2.67E-7)]
-        [TestCase(103993, 33102, 5.78E-10)]
-        [TestCase(104348, 33215, 3.32E-10)]
-        [TestCase(208341, 66317, 1.23E-10)]
-        [TestCase(312689, 99532, 2.92E-11)]
-        [TestCase(833719, 265381, 8.72E-12)]
-        [TestCase(1146408, 364913, 1.62E-12)]
+        [TestCase(3, 1, 1.42E-1, Category = "ApproximatePI")]
+        [TestCase(22, 7, 1.27E-3, Category = "ApproximatePI")]
+        [TestCase(333, 106, 8.33E-5, Category = "ApproximatePI")]
+        [TestCase(355, 113, 2.67E-7, Category = "ApproximatePI")]
+        [TestCase(103993, 33102, 5.78E-10, Category = "ApproximatePI")]
+        [TestCase(104348, 33215, 3.32E-10, Category = "ApproximatePI")]
+        [TestCase(208341, 66317, 1.23E-10, Category = "ApproximatePI")]
+        [TestCase(312689, 99532, 2.92E-11, Category = "ApproximatePI")]
+        [TestCase(833719, 265381, 8.72E-12, Category = "ApproximatePI")]
+        [TestCase(1146408, 364913, 1.62E-12, Category = "ApproximatePI")]
         public void ApproximatePI(int expectedNumerator, int expectedDenominator, double tolerance)
         {
             // action
@@ -65,14 +65,14 @@ namespace RationalTests
             Assert.AreEqual((Rational) expectedNumerator / expectedDenominator, rational);
         }
 
-        [TestCase("0.333", "0.0001", 333, 1000)]
-        [TestCase("-0.333", "0.0001", -333, 1000)]
-        [TestCase("0.333", "0.001", 1, 3)]
-        [TestCase("-0.333", "0.001", -1, 3)]
-        [TestCase("2.5", "0", 5, 2)]
-        [TestCase("-2.5", "0", -5, 2)]
-        [TestCase("-1", "0", -1, 1)]
-        [TestCase("1", "0", 1, 1)]
+        [TestCase("0.333", "0.0001", 333, 1000, Category = "ApproximateDecimal")]
+        [TestCase("-0.333", "0.0001", -333, 1000, Category = "ApproximateDecimal")]
+        [TestCase("0.333", "0.001", 1, 3, Category = "ApproximateDecimal")]
+        [TestCase("-0.333", "0.001", -1, 3, Category = "ApproximateDecimal")]
+        [TestCase("2.5", "0", 5, 2, Category = "ApproximateDecimal")]
+        [TestCase("-2.5", "0", -5, 2, Category = "ApproximateDecimal")]
+        [TestCase("-1", "0", -1, 1, Category = "ApproximateDecimal")]
+        [TestCase("1", "0", 1, 1, Category = "ApproximateDecimal")]
         public void ApproximateDecimal(string inputStr, string toleranceStr, int expectedNumerator,
             int expectedDenominator)
         {

--- a/RationalTests/BaseTests.cs
+++ b/RationalTests/BaseTests.cs
@@ -8,18 +8,13 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Base Tests")]
     public class BaseTests
     {
         [Test]

--- a/RationalTests/CanonicalTests.cs
+++ b/RationalTests/CanonicalTests.cs
@@ -8,18 +8,13 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Canonical Form")]
     public class CanonicalTests
     {
         [Test]

--- a/RationalTests/ComparisonsTests.cs
+++ b/RationalTests/ComparisonsTests.cs
@@ -8,18 +8,14 @@
 
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Comparisons")]
     public class ComparisonsTests
     {
         [Test]

--- a/RationalTests/ContinuedFractionsTests.cs
+++ b/RationalTests/ContinuedFractionsTests.cs
@@ -8,18 +8,13 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Continued Fractions")]
     public class ContinuedFractionsTests
     {
         [Test]

--- a/RationalTests/ExplicitFloatingPointConversionsTests.cs
+++ b/RationalTests/ExplicitFloatingPointConversionsTests.cs
@@ -315,7 +315,6 @@ namespace RationalTests
             Assert.AreEqual(d, converted, doubleDelta);
         }
 
-
         [Test]
         public void ToFloat1()
         {

--- a/RationalTests/ExplicitFloatingPointConversionsTests.cs
+++ b/RationalTests/ExplicitFloatingPointConversionsTests.cs
@@ -131,7 +131,6 @@ namespace RationalTests
             });
         }
 
-
         [Test]
         public void FromDouble_MaxValue_Throws()
         {

--- a/RationalTests/ExplicitFloatingPointConversionsTests.cs
+++ b/RationalTests/ExplicitFloatingPointConversionsTests.cs
@@ -19,7 +19,7 @@ using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Explicit Floating Point Conversions")]
     public class ExplicitFloatingPointConversionsTests
     {
         private const double doubleDelta = 1.0E-15d;

--- a/RationalTests/ExtendedPropertiesTests.cs
+++ b/RationalTests/ExtendedPropertiesTests.cs
@@ -46,7 +46,7 @@ namespace RationalTests
         {
             // arrange
             var rationals = new[]
-            {1, 0, -1, (Rational) 5 / 4, 2, -2, 4, 8, 16, (Rational) 1 / 2, (Rational) 4 / 16, 64, (Rational) 1024 / 3};
+            { 1, 0, -1, (Rational) 5 / 4, 2, -2, 4, 8, 16, (Rational) 1 / 2, (Rational) 4 / 16, 64, (Rational) 1024 / 3 };
 
             // action
             var powers = rationals.Where(x => x.IsPowerOfTwo).ToList();

--- a/RationalTests/ExtendedPropertiesTests.cs
+++ b/RationalTests/ExtendedPropertiesTests.cs
@@ -8,18 +8,13 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Extended Properties")]
     public class ExtendedPropertiesTests
     {
         [Test]

--- a/RationalTests/FormattingTests.cs
+++ b/RationalTests/FormattingTests.cs
@@ -8,18 +8,13 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Formatting")]
     public class FormattingTests
     {
         [Test]

--- a/RationalTests/ImplicitConversionTests.cs
+++ b/RationalTests/ImplicitConversionTests.cs
@@ -8,18 +8,13 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Implicit Conversion")]
     public class ImplicitConversionTests
     {
         [Test]

--- a/RationalTests/OperationsTests.cs
+++ b/RationalTests/OperationsTests.cs
@@ -8,18 +8,12 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category ="Operations")]
     public class OperationsTests
     {
         [Test]

--- a/RationalTests/OperationsTests.cs
+++ b/RationalTests/OperationsTests.cs
@@ -13,7 +13,7 @@ using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture(Category ="Operations")]
+    [TestFixture(Category = "Operations")]
     public class OperationsTests
     {
         [Test]

--- a/RationalTests/ParsingTests.cs
+++ b/RationalTests/ParsingTests.cs
@@ -19,7 +19,7 @@ using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category = "Parsing")]
     public class ParsingTests
     {
         [TestCase(@"3/4", true, 3, 4)]

--- a/RationalTests/WholeAndFractionTests.cs
+++ b/RationalTests/WholeAndFractionTests.cs
@@ -14,7 +14,7 @@ using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture(Category ="Whole and Fraction")]
+    [TestFixture(Category = "Whole and Fraction")]
     public class WholeAndFractionTests
     {
         [Test]

--- a/RationalTests/WholeAndFractionTests.cs
+++ b/RationalTests/WholeAndFractionTests.cs
@@ -8,18 +8,13 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Numerics;
-using System.Text;
 using NUnit.Framework;
 using Rationals;
 
 namespace RationalTests
 {
-    [TestFixture]
+    [TestFixture(Category ="Whole and Fraction")]
     public class WholeAndFractionTests
     {
         [Test]


### PR DESCRIPTION
I did some organization on the tests by category so that one can test only a part of the test set without needing to be hunting for the functions to be selected. This made easier for me to debug a parsing problem I was having on my machine due to be using different culture than expected on the test.