### PR TITLE
Issue#22 Fixed comparison when one of denominators is negative and both numbers are positive

### DIFF
--- a/src/Rationals/Comparisons.cs
+++ b/src/Rationals/Comparisons.cs
@@ -66,12 +66,9 @@ namespace Rationals
         {
             if (Sign == other.Sign)
             {
-                if (Sign >= 0)
-                    return (Numerator * other.Denominator).CompareTo(other.Numerator * Denominator);
-
-                return
-                    -BigInteger.Abs(Numerator * other.Denominator)
-                        .CompareTo(BigInteger.Abs(other.Numerator * Denominator));
+                BigInteger adjDenominator = BigInteger.Abs(Denominator) * other.Denominator.Sign;
+                BigInteger adjOtherDenominator = BigInteger.Abs(other.Denominator) * Denominator.Sign;
+                return (Numerator * adjOtherDenominator).CompareTo(other.Numerator * adjDenominator);
             }
 
             if (Sign > other.Sign)

--- a/tests/Rationals.Tests/ComparisonsTests.cs
+++ b/tests/Rationals.Tests/ComparisonsTests.cs
@@ -61,6 +61,27 @@ namespace Rationals.Tests
         }
 
         [Fact]
+        public void ComparisonsNegativeDenominator()
+        {
+            // arrange
+            var a = new Rational(3);
+            var b = new Rational(-4, -1);
+
+            // assert
+            Assert.Equal(-1, a.CompareTo(b));
+            Assert.False(a > b);
+            Assert.False(a >= b);
+            Assert.True(a < b);
+            Assert.True(a <= b);
+
+            Assert.Equal(+1, b.CompareTo(a));
+            Assert.True(b > a);
+            Assert.True(b >= a);
+            Assert.False(b < a);
+            Assert.False(b <= a);
+        }
+
+        [Fact]
         public void Equality1()
         {
             // arrange


### PR DESCRIPTION
When we try to transform equation
`a/b < c/d`
we can't just multiply both sides by `b` and `d`:
`a*d < c*b` - this is wrong because some of denominators can be negative and therefore we should switch the sign (from `<` to `>`) in such case. However we can multiply by absolute value.
I.e.
`a*ABS(d)/SIGN(b) < c*ABS(b)/SIGN(d)`
Then we can move sign from denominators to numerators
`a*ABS(d)*SIGN(b) < c*ABS(b)*SIGN(d)`