### PR TITLE
#24 Treat default(Rational) as Zero

### DIFF
--- a/src/Rationals/Base.cs
+++ b/src/Rationals/Base.cs
@@ -8,6 +8,9 @@ namespace Rationals
     /// </summary>
     public partial struct Rational
     {
+        private readonly BigInteger _numerator;
+        private readonly BigInteger _denominator;
+
         /// <summary>
         /// Constructs rational number out of a whole number.
         /// </summary>
@@ -21,8 +24,8 @@ namespace Rationals
             if (denominator == 0)
                 throw new DivideByZeroException("Denominator cannot be zero.");
 
-            Numerator = numerator;
-            Denominator = denominator;
+            _numerator = numerator;
+            _denominator = denominator;
         }
 
         /// <summary>
@@ -33,18 +36,25 @@ namespace Rationals
             if (denominator == 0)
                 throw new DivideByZeroException("Denominator cannot be zero.");
 
-            Numerator = numerator;
-            Denominator = denominator;
+            _numerator = numerator;
+            _denominator = denominator;
         }
 
         /// <summary>
         /// Numerator part of the rational number.
         /// </summary>
-        public BigInteger Numerator { get; }
+        public BigInteger Numerator
+        {
+            get => _numerator;
+        }
 
         /// <summary>
         /// Denominator part of the rational number.
         /// </summary>
-        public BigInteger Denominator { get; }
+        public BigInteger Denominator
+        {
+            // denominator can be 0 when an instance is created using default constructor
+            get => _denominator == 0 ? BigInteger.One : _denominator;
+        }
     }
 }

--- a/tests/Rationals.Tests/ComparisonsTests.cs
+++ b/tests/Rationals.Tests/ComparisonsTests.cs
@@ -262,5 +262,46 @@ namespace Rationals.Tests
             };
             Assert.Equal(expected, sorted);
         }
+
+        [Fact]
+        public void DefaultValue_IsZero()
+        {
+            Assert.True(default(Rational).IsZero);
+        }
+
+        [Fact]
+        public void DefaultValue_Not_IsOne()
+        {
+            Assert.False(default(Rational).IsOne);
+        }
+
+        [Fact]
+        public void DefaultValue_Numerator_0()
+        {
+            Assert.Equal(0, default(Rational).Numerator);
+        }
+
+        [Fact]
+        public void DefaultValue_Denominator_1()
+        {
+            Assert.Equal(1, default(Rational).Denominator);
+        }
+
+        [Fact]
+        public void DefaultValue_EqualTo0()
+        {
+            Assert.Equal(0, default(Rational));
+        }
+
+        [Fact]
+        public void DefaultValue_Not_EqualTo10_Left()
+        {
+            Assert.False(default(Rational) == 10);
+        }
+        [Fact]
+        public void DefaultValue_Not_EqualTo10_Right()
+        {
+            Assert.False(10 == default(Rational));
+        }
     }
 }


### PR DESCRIPTION
I like the idea to treat `default(Rational)` (which is `(0/0)` internally) as `NaN`, however for completeness I would propose the alternative way to treat `default(Rational)` as `Zero`.